### PR TITLE
add channel to sign_in and sign_up options

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -193,6 +193,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         options = credentials.get("options", {})
         redirect_to = options.get("redirect_to")
         data = options.get("data") or {}
+        channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")
         if email:
             response = await self._request(
@@ -217,6 +218,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
                     "phone": phone,
                     "password": password,
                     "data": data,
+                    "channel": channel,
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },
@@ -419,6 +421,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         email_redirect_to = options.get("email_redirect_to")
         should_create_user = options.get("create_user", True)
         data = options.get("data")
+        channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")
         if email:
             return await self._request(
@@ -443,6 +446,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
                     "phone": phone,
                     "data": data,
                     "create_user": should_create_user,
+                    "channel": channel,
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },

--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -191,7 +191,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         phone = credentials.get("phone")
         password = credentials.get("password")
         options = credentials.get("options", {})
-        redirect_to = options.get("redirct_to") or options.get("email_redirect_to")
+        redirect_to = options.get("redirect_to") or options.get("email_redirect_to")
         data = options.get("data") or {}
         channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")

--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -191,7 +191,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         phone = credentials.get("phone")
         password = credentials.get("password")
         options = credentials.get("options", {})
-        redirect_to = options.get("redirect_to")
+        redirect_to = options.get("redirct_to") or options.get("email_redirect_to")
         data = options.get("data") or {}
         channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -193,6 +193,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         options = credentials.get("options", {})
         redirect_to = options.get("redirect_to")
         data = options.get("data") or {}
+        channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")
         if email:
             response = self._request(
@@ -217,6 +218,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
                     "phone": phone,
                     "password": password,
                     "data": data,
+                    "channel": channel,
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },
@@ -419,6 +421,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         email_redirect_to = options.get("email_redirect_to")
         should_create_user = options.get("create_user", True)
         data = options.get("data")
+        channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")
         if email:
             return self._request(
@@ -443,6 +446,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
                     "phone": phone,
                     "data": data,
                     "create_user": should_create_user,
+                    "channel": channel,
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -588,9 +588,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         self._notify_all_subscribers("TOKEN_REFRESHED", session)
         return AuthResponse(session=session, user=response.user)
 
-    def refresh_session(
-        self, refresh_token: Union[str, None] = None
-    ) -> AuthResponse:
+    def refresh_session(self, refresh_token: Union[str, None] = None) -> AuthResponse:
         """
         Returns a new session, regardless of expiry status.
 
@@ -981,9 +979,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         if self._flow_type == "pkce":
             code_verifier = generate_pkce_verifier()
             code_challenge = generate_pkce_challenge(code_verifier)
-            self._storage.set_item(
-                f"{self._storage_key}-code-verifier", code_verifier
-            )
+            self._storage.set_item(f"{self._storage_key}-code-verifier", code_verifier)
             code_challenge_method = (
                 "plain" if code_verifier == code_challenge else "s256"
             )

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -191,7 +191,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         phone = credentials.get("phone")
         password = credentials.get("password")
         options = credentials.get("options", {})
-        redirect_to = options.get("redirect_to")
+        redirect_to = options.get("redirct_to") or options.get("email_redirect_to")
         data = options.get("data") or {}
         channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")
@@ -588,7 +588,9 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         self._notify_all_subscribers("TOKEN_REFRESHED", session)
         return AuthResponse(session=session, user=response.user)
 
-    def refresh_session(self, refresh_token: Union[str, None] = None) -> AuthResponse:
+    def refresh_session(
+        self, refresh_token: Union[str, None] = None
+    ) -> AuthResponse:
         """
         Returns a new session, regardless of expiry status.
 
@@ -979,7 +981,9 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         if self._flow_type == "pkce":
             code_verifier = generate_pkce_verifier()
             code_challenge = generate_pkce_challenge(code_verifier)
-            self._storage.set_item(f"{self._storage_key}-code-verifier", code_verifier)
+            self._storage.set_item(
+                f"{self._storage_key}-code-verifier", code_verifier
+            )
             code_challenge_method = (
                 "plain" if code_verifier == code_challenge else "s256"
             )

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -191,7 +191,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         phone = credentials.get("phone")
         password = credentials.get("password")
         options = credentials.get("options", {})
-        redirect_to = options.get("redirct_to") or options.get("email_redirect_to")
+        redirect_to = options.get("redirect_to") or options.get("email_redirect_to")
         data = options.get("data") or {}
         channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -260,6 +260,7 @@ class SignUpWithEmailAndPasswordCredentials(TypedDict):
 class SignUpWithPhoneAndPasswordCredentialsOptions(TypedDict):
     data: NotRequired[Any]
     captcha_token: NotRequired[str]
+    channel: NotRequired[Literal["sms", "whatsapp"]]
 
 
 class SignUpWithPhoneAndPasswordCredentials(TypedDict):
@@ -313,6 +314,7 @@ class SignInWithPhoneAndPasswordlessCredentialsOptions(TypedDict):
     should_create_user: NotRequired[bool]
     data: NotRequired[Any]
     captcha_token: NotRequired[str]
+    channel: NotRequired[Literal["sms", "whatsapp"]]
 
 
 class SignInWithPhoneAndPasswordlessCredentials(TypedDict):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add missing feature

## What is the current behavior?

When using phone auth you can only use `sms` as a channel

## What is the new behavior?

When using phone auth you can now use `sms` or `whatsapp` as a channel

## Additional context

Add any other context or screenshots.
