### PR TITLE
update property name for should_create_user

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -442,7 +442,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         phone = credentials.get("phone")
         options = credentials.get("options", {})
         email_redirect_to = options.get("email_redirect_to")
-        should_create_user = options.get("create_user", True)
+        should_create_user = options.get("should_create_user", True)
         data = options.get("data")
         channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -436,7 +436,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         phone = credentials.get("phone")
         options = credentials.get("options", {})
         email_redirect_to = options.get("email_redirect_to")
-        should_create_user = options.get("create_user", True)
+        should_create_user = options.get("should_create_user", True)
         data = options.get("data")
         channel = options.get("channel", "sms")
         captcha_token = options.get("captcha_token")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently the `should_create_user` property is incorrectly named inside the `sign_in_with_otp` method

## What is the new behavior?

The `should_create_user` property is correctly named inside the `sign_in_with_otp` method

## Additional context

Add any other context or screenshots.
