### PR TITLE
Remove unnecessary async method definitions from AsyncStorage

### DIFF
--- a/supabase_auth/_async/storage.py
+++ b/supabase_auth/_async/storage.py
@@ -6,26 +6,26 @@ from typing import Dict, Optional
 
 class AsyncSupportedStorage(ABC):
     @abstractmethod
-    async def get_item(self, key: str) -> Optional[str]: ...  # pragma: no cover
+    def get_item(self, key: str) -> Optional[str]: ...  # pragma: no cover
 
     @abstractmethod
-    async def set_item(self, key: str, value: str) -> None: ...  # pragma: no cover
+    def set_item(self, key: str, value: str) -> None: ...  # pragma: no cover
 
     @abstractmethod
-    async def remove_item(self, key: str) -> None: ...  # pragma: no cover
+    def remove_item(self, key: str) -> None: ...  # pragma: no cover
 
 
 class AsyncMemoryStorage(AsyncSupportedStorage):
     def __init__(self):
         self.storage: Dict[str, str] = {}
 
-    async def get_item(self, key: str) -> Optional[str]:
+    def get_item(self, key: str) -> Optional[str]:
         if key in self.storage:
             return self.storage[key]
 
-    async def set_item(self, key: str, value: str) -> None:
+    def set_item(self, key: str, value: str) -> None:
         self.storage[key] = value
 
-    async def remove_item(self, key: str) -> None:
+    def remove_item(self, key: str) -> None:
         if key in self.storage:
             del self.storage[key]


### PR DESCRIPTION
Removed the non-required async definitions and await operations with async storage, resulting in `TypeError: object NoneType can't be used in 'await' expression` errors if the session is not defined before get_session is called with tokens. (or in any case when data is set to `None` before trying to retrieve it)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When creating supabase through `create_async_client` it's not possible to set/get the session with tokens due to the mentioned issue.

## What is the new behavior?

After async def and awaits are removed everything works. (tested originally with local changes in the files, additional context reveals actual testing against committed changes was not possible)

## Additional context

I couldn't run tests against the pull request because pytest doesn't work and because it's impossible to replace the library's installation for supabase(py) because it still refers to the old gotrue project. Also, I'm not sure if there's a requirement for the async behavior so this PR might be against the needs, but as I can't use the library at all before this is fixed I'm forced to make this pull request asap.

Problems were encountered in Python 3.12.3 while running langserve through langchain. As I'm not an experienced Python developer there might be something I'm missing here. Feel free to comment or modify the pull request where needed.

Thanks,