### PR TITLE
add sign_in_with_id_token method

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -307,7 +307,6 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         access_token = credentials.get("access_token")
         nonce = credentials.get("nonce")
         options = credentials.get("options", {})
-        data = options.get("data") or {}
         captcha_token = options.get("captcha_token")
 
         response = await self._request(

--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -63,6 +63,7 @@ from ..types import (
     Provider,
     Session,
     SignInAnonymouslyCredentials,
+    SignInWithIdTokenCredentials,
     SignInWithOAuthCredentials,
     SignInWithPasswordCredentials,
     SignInWithPasswordlessCredentials,
@@ -288,6 +289,45 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             raise AuthInvalidCredentialsError(
                 "You must provide either an email or phone number and a password"
             )
+        if response.session:
+            await self._save_session(response.session)
+            self._notify_all_subscribers("SIGNED_IN", response.session)
+        return response
+
+    async def sign_in_with_id_token(
+        self,
+        credentials: SignInWithIdTokenCredentials,
+    ) -> AuthResponse:
+        """
+        Allows signing in with an OIDC ID token. The authentication provider used should be enabled and configured.
+        """
+        await self._remove_session()
+        provider = credentials.get("provider")
+        token = credentials.get("token")
+        access_token = credentials.get("access_token")
+        nonce = credentials.get("nonce")
+        options = credentials.get("options", {})
+        data = options.get("data") or {}
+        captcha_token = options.get("captcha_token")
+
+        response = await self._request(
+            "POST",
+            "token",
+            body={
+                "provider": provider,
+                "id_token": token,
+                "access_token": access_token,
+                "nonce": nonce,
+                "gotrue_meta_security": {
+                    "captcha_token": captcha_token,
+                },
+            },
+            query={
+                "grant_type": "id_token",
+            },
+            xform=parse_auth_response,
+        )
+
         if response.session:
             await self._save_session(response.session)
             self._notify_all_subscribers("SIGNED_IN", response.session)

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -307,7 +307,6 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         access_token = credentials.get("access_token")
         nonce = credentials.get("nonce")
         options = credentials.get("options", {})
-        data = options.get("data") or {}
         captcha_token = options.get("captcha_token")
 
         response = self._request(

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -63,6 +63,7 @@ from ..types import (
     Provider,
     Session,
     SignInAnonymouslyCredentials,
+    SignInWithIdTokenCredentials,
     SignInWithOAuthCredentials,
     SignInWithPasswordCredentials,
     SignInWithPasswordlessCredentials,
@@ -288,6 +289,45 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             raise AuthInvalidCredentialsError(
                 "You must provide either an email or phone number and a password"
             )
+        if response.session:
+            self._save_session(response.session)
+            self._notify_all_subscribers("SIGNED_IN", response.session)
+        return response
+
+    def sign_in_with_id_token(
+        self,
+        credentials: SignInWithIdTokenCredentials,
+    ) -> AuthResponse:
+        """
+        Allows signing in with an OIDC ID token. The authentication provider used should be enabled and configured.
+        """
+        self._remove_session()
+        provider = credentials.get("provider")
+        token = credentials.get("token")
+        access_token = credentials.get("access_token")
+        nonce = credentials.get("nonce")
+        options = credentials.get("options", {})
+        data = options.get("data") or {}
+        captcha_token = options.get("captcha_token")
+
+        response = self._request(
+            "POST",
+            "token",
+            body={
+                "provider": provider,
+                "id_token": token,
+                "access_token": access_token,
+                "nonce": nonce,
+                "gotrue_meta_security": {
+                    "captcha_token": captcha_token,
+                },
+            },
+            query={
+                "grant_type": "id_token",
+            },
+            xform=parse_auth_response,
+        )
+
         if response.session:
             self._save_session(response.session)
             self._notify_all_subscribers("SIGNED_IN", response.session)

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -303,6 +303,22 @@ SignInWithPasswordCredentials = Union[
 ]
 
 
+class SignInWithIdTokenCredentials(TypedDict):
+    """
+    Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `keycloak` (deprecated).
+    """
+
+    provider: Literal["google", "apple", "azure", "facebook"]
+    token: str
+    access_token: NotRequired[str]
+    nonce: NotRequired[str]
+    options: NotRequired[SignInWithIdTokenCredentialsOptions]
+
+
+class SignInWithIdTokenCredentialsOptions(TypedDict):
+    captcha_token: NotRequired[str]
+
+
 class SignInWithEmailAndPasswordlessCredentialsOptions(TypedDict):
     email_redirect_to: NotRequired[str]
     should_create_user: NotRequired[bool]

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -305,10 +305,10 @@ SignInWithPasswordCredentials = Union[
 
 class SignInWithIdTokenCredentials(TypedDict):
     """
-    Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `keycloak` (deprecated).
+    Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `kakao`, `keycloak` (deprecated).
     """
 
-    provider: Literal["google", "apple", "azure", "facebook"]
+    provider: Literal["google", "apple", "azure", "facebook", "kakao"]
     token: str
     access_token: NotRequired[str]
     nonce: NotRequired[str]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add the `sign_in_with_id_token` method for Google and others one tap integration.

## What is the current behavior?

There is no `sign_in_with_id_token` method

## What is the new behavior?

There is now a `sign_in_with_id_token` method

## Additional context

Add any other context or screenshots.
