### PR TITLE
add is_anonymous type to the user model

### DIFF
--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -199,6 +199,7 @@ class User(BaseModel):
     recovery_sent_at: Union[datetime, None] = None
     email_change_sent_at: Union[datetime, None] = None
     new_email: Union[str, None] = None
+    new_phone: Union[str, None] = None
     invited_at: Union[datetime, None] = None
     action_link: Union[str, None] = None
     email: Union[str, None] = None
@@ -211,6 +212,7 @@ class User(BaseModel):
     role: Union[str, None] = None
     updated_at: Union[datetime, None] = None
     identities: Union[List[UserIdentity], None] = None
+    is_anonymous: bool = False
     factors: Union[List[Factor], None] = None
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently the returned user model doesn't show the `is_anonymous` type

## What is the new behavior?

The returned user model shows the `is_anonymous` type

## Additional context

Add any other context or screenshots.
